### PR TITLE
fix for not using corner map

### DIFF
--- a/MinimapIcons.cs
+++ b/MinimapIcons.cs
@@ -48,10 +48,10 @@ namespace MinimapIcons
                 if (ingameStateIngameUi.Map.SmallMiniMap.IsVisibleLocal)
                 {
                     var mapRect = ingameStateIngameUi.Map.SmallMiniMap.GetClientRect();
-                    return (float) (Math.Sqrt(mapRect.Width * mapRect.Width + mapRect.Height * mapRect.Height) / 2f);
+                    return (float)(Math.Sqrt(mapRect.Width * mapRect.Width + mapRect.Height * mapRect.Height) / 2f);
                 }
 
-                return (float) Math.Sqrt(camera.Width * camera.Width + camera.Height * camera.Height);
+                return (float)Math.Sqrt(camera.Width * camera.Width + camera.Height * camera.Height);
             }, 100)).Value;
         private Vector2 screenCenter =>
             new Vector2(MapRect.Width / 2, MapRect.Height / 2 - 20) + new Vector2(MapRect.X, MapRect.Y) +
@@ -114,7 +114,7 @@ namespace MinimapIcons
 
         public override void Render()
         {
-            if (!Settings.Enable.Value || !GameController.InGame || Settings.DrawOnlyOnLargeMap && !largeMap) return;
+            if (!Settings.Enable.Value || !GameController.InGame || Settings.DrawOnlyOnLargeMap && !ingameStateIngameUi.Map.LargeMap.IsVisible) return;
 
             if (!Settings.IgnoreFullscreenPanels &&
                 ingameStateIngameUi.FullscreenPanels.Any(x => x.IsVisible) ||
@@ -208,10 +208,10 @@ namespace MinimapIcons
                             continue;
 
 
-                        if (icon.HasIngameIcon && 
-                            icon.Entity.Type != EntityType.Monster && 
-                            icon.Entity.League != LeagueType.Heist && 
-                            !Settings.DrawReplacementsForGameIconsWhenOutOfRange && 
+                        if (icon.HasIngameIcon &&
+                            icon.Entity.Type != EntityType.Monster &&
+                            icon.Entity.League != LeagueType.Heist &&
+                            !Settings.DrawReplacementsForGameIconsWhenOutOfRange &&
                             !icon.Entity.Path.Contains("Metadata/Terrain/Leagues/Delve/Objects/DelveWall"))
                             continue;
 

--- a/MinimapIcons.cs
+++ b/MinimapIcons.cs
@@ -36,7 +36,7 @@ namespace MinimapIcons
 
         private IngameUIElements ingameStateIngameUi;
         private float k;
-        private bool largeMap;
+        private bool? largeMap;
         private float scale;
         private Vector2 screentCenterCache;
         private RectangleF MapRect => _mapRect?.Value ?? (_mapRect = new TimeCache<RectangleF>(() => mapWindow.GetClientRect(), 100)).Value;
@@ -107,6 +107,10 @@ namespace MinimapIcons
                 screentCenterCache = screenCenter;
                 largeMap = true;
             }
+            else
+            {
+                largeMap = null;
+            }
 
             k = camera.Width < 1024f ? 1120f : 1024f;
             scale = k / camera.Height * camera.Width * 3f / 4f / mapWindow.LargeMapZoom;
@@ -114,7 +118,7 @@ namespace MinimapIcons
 
         public override void Render()
         {
-            if (!Settings.Enable.Value || !GameController.InGame || Settings.DrawOnlyOnLargeMap && !ingameStateIngameUi.Map.LargeMap.IsVisible) return;
+            if (!Settings.Enable.Value || !GameController.InGame || Settings.DrawOnlyOnLargeMap && largeMap != true) return;
 
             if (!Settings.IgnoreFullscreenPanels &&
                 ingameStateIngameUi.FullscreenPanels.Any(x => x.IsVisible) ||
@@ -160,15 +164,19 @@ namespace MinimapIcons
 
                 Vector2 position;
 
-                if (largeMap)
+                if (largeMap == true)
                 {
                     position = screentCenterCache + MapIcon.DeltaInWorldToMinimapDelta(
                                    icon.GridPositionNum() - playerPos, diag, scale, (iconZ - posZ) / (9f / mapWindowLargeMapZoom));
                 }
-                else
+                else if (largeMap == false)
                 {
                     position = screentCenterCache +
                                MapIcon.DeltaInWorldToMinimapDelta(icon.GridPositionNum() - playerPos, diag, 240f, (iconZ - posZ) / 20);
+                }
+                else
+                {
+                    continue;
                 }
 
                 var iconValueMainTexture = icon.MainTexture;
@@ -218,15 +226,19 @@ namespace MinimapIcons
                         var iconZ = icon.Entity.PosNum.Z;
                         Vector2 position;
 
-                        if (largeMap)
+                        if (largeMap == true)
                         {
                             position = screentCenterCache + MapIcon.DeltaInWorldToMinimapDelta(
                                 icon.GridPositionNum() - playerPos, diag, scale, (iconZ - posZ) / (9f / mapWindowLargeMapZoom));
                         }
-                        else
+                        else if (largeMap == false)
                         {
                             position = screentCenterCache +
                                        MapIcon.DeltaInWorldToMinimapDelta(icon.GridPositionNum() - playerPos, diag, 240f, (iconZ - posZ) / 20);
+                        }
+                        else
+                        {
+                            continue;
                         }
 
                         HudTexture iconValueMainTexture = icon.MainTexture;


### PR DESCRIPTION
When "Show Corner Map" is disabled in the game's UI settings, icons never stop to be drawn, even when the large map overlay is closed. 

Not using largeMap to determine the early return in Render() seems to fix it for me.
