### PR TITLE
Add "Hidden icons" rules, applied at draw time

### DIFF
--- a/MapIconsSettings.cs
+++ b/MapIconsSettings.cs
@@ -2,8 +2,59 @@
 using ExileCore.Shared.Interfaces;
 using ExileCore.Shared.Nodes;
 using MinimapIcons.IconsBuilder;
+using System;
 
 namespace MinimapIcons;
+
+/// <summary>
+/// One "never draw an icon for this" entry, editable from the plugin menu.
+/// </summary>
+/// <remarks>
+/// The existing ignore mechanisms are both applied when the icon is *built*: entries in
+/// <c>ignored_entities.txt</c> and in <see cref="MinimapIcons.Ignored"/> make
+/// <c>IconsBuilder.SkipIcon</c> return before an icon object exists. That is fine for a
+/// permanent exclusion, but it means an entry cannot be undone without an area change, and
+/// the hardcoded list cannot be undone at all. These rules are applied at draw time instead,
+/// so toggling one takes effect on the next frame in both directions.
+/// </remarks>
+[Submenu]
+public class IconIgnoreRule
+{
+    public IconIgnoreRule()
+    {
+    }
+
+    public IconIgnoreRule(string label, string metadataRegex, bool hide)
+    {
+        Label = new TextNode(label);
+        MetadataRegex = new TextNode(metadataRegex);
+        Hide = new ToggleNode(hide);
+    }
+
+    [Menu("Hide", "On = matching entities get no icon. Off = they draw as normal.")]
+    public ToggleNode Hide { get; set; } = new ToggleNode(true);
+
+    [Menu("Label", "Free text, so the row is recognisable in this list. Not used for matching.")]
+    public TextNode Label { get; set; } = new TextNode("");
+
+    [Menu("Metadata regex", "Unanchored regex tested against the entity metadata path.")]
+    public TextNode MetadataRegex { get; set; } = new TextNode("");
+
+    // Names the row in the settings UI, which otherwise falls back to object.ToString() and shows
+    // every row as "MinimapIcons.IconIgnoreRule". The trailing ### keeps the ImGui id of the row
+    // stable while the visible part of the label changes, so the row does not collapse itself
+    // while you are typing in the label or pattern field.
+    public override string ToString()
+    {
+        var label = !string.IsNullOrWhiteSpace(Label?.Value)
+            ? Label.Value
+            : !string.IsNullOrWhiteSpace(MetadataRegex?.Value)
+                ? MetadataRegex.Value
+                : "(empty rule)";
+
+        return $"{label}###";
+    }
+}
 
 public class MapIconsSettings : ISettings
 {
@@ -20,6 +71,23 @@ public class MapIconsSettings : ISettings
     public ToggleNode Enable { get; set; } = new ToggleNode(true);
     public RangeNode<int> IconListRefreshPeriod { get; set; } = new RangeNode<int>(100, 0, 1000);
     public ToggleNode HighlightHiddenMonsters { get; set; } = new ToggleNode(true);
+
+    [Menu("Hidden icons", "Entities you never want an icon for, each with its own on/off. Unlike " +
+                          "ignored_entities.txt these are applied at draw time, so a toggle takes effect " +
+                          "immediately and can be undone without changing areas. Empty by default.",
+        CollapsedByDefault = true)]
+    public ContentNode<IconIgnoreRule> HiddenIcons { get; set; } =
+        new ContentNode<IconIgnoreRule>()
+        {
+            Content =
+            [
+            ],
+            EnableControls = true,
+            EnableItemCollapsing = true,
+            ItemFactory = () => new IconIgnoreRule(),
+            ItemFilter = (o, s) => o.Label.Value.Contains(s, StringComparison.OrdinalIgnoreCase) ||
+                                   o.MetadataRegex.Value.Contains(s, StringComparison.OrdinalIgnoreCase),
+        };
 
     [Menu(null, CollapsedByDefault = true)]
     public ContentNode<TextNode> AlwaysShownIngameIcons { get; set; } =

--- a/MinimapIcons.cs
+++ b/MinimapIcons.cs
@@ -11,6 +11,7 @@ using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Color = SharpDX.Color;
 using RectangleF = SharpDX.RectangleF;
 using Vector2 = System.Numerics.Vector2;
@@ -158,6 +159,18 @@ public class MinimapIcons : BaseSettingsPlugin<MapIconsSettings>
 
     private readonly Dictionary<string, bool> IgnoreCache = new Dictionary<string, bool>();
 
+    // Compiled regexes for Settings.HiddenIcons keyed by pattern text, plus the per-path answers
+    // derived from them. A breach puts hundreds of icons behind a handful of distinct paths, so
+    // this turns the regex work into a dictionary hit after the first sighting of each path.
+    private readonly Dictionary<string, Regex> _hiddenIconRegexes = new(StringComparer.Ordinal);
+    private readonly HashSet<string> _badHiddenIconPatterns = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, bool> _hiddenIconCache = new(StringComparer.Ordinal);
+
+    // Cheap hash of the rule set, so an edit in the menu invalidates the cache above. Recomputed
+    // once per frame rather than per icon, and an int rather than a joined string, because
+    // Render() runs every frame and should not allocate.
+    private int _hiddenIconSignature;
+
     private IngameUIElements _ingameUi;
     private bool? _largeMap;
     private float _mapScale;
@@ -257,6 +270,8 @@ public class MinimapIcons : BaseSettingsPlugin<MapIconsSettings>
         var baseIcons = _iconListCache.Value;
         if (baseIcons == null) return;
 
+        RefreshHiddenIconRules();
+
         foreach (var icon in baseIcons)
         {
             if (icon?.Entity == null) continue;
@@ -265,6 +280,9 @@ public class MinimapIcons : BaseSettingsPlugin<MapIconsSettings>
                 continue;
 
             if (IgnoreCache.GetOrAdd(icon.Entity.Path, () => Ignored.Any(x => icon.Entity.Path.StartsWith(x))))
+                continue;
+
+            if (IsHiddenByRule(icon.Entity.Path))
                 continue;
 
             if (icon.Entity.Path.StartsWith(
@@ -313,6 +331,76 @@ public class MinimapIcons : BaseSettingsPlugin<MapIconsSettings>
 
             if (!string.IsNullOrEmpty(icon.Text))
                 Graphics.DrawText(icon.Text, position.Translate(0, Settings.ZForText), icon.TextColor?.ToSharpDx() ?? Color.White, FontAlign.Center);
+        }
+    }
+
+    /// <summary>
+    /// Drops the cached per-path answers whenever a rule's toggle or pattern changes, so an edit
+    /// in the menu takes effect on the next frame. Called once per frame, before the icon loop.
+    /// </summary>
+    private void RefreshHiddenIconRules()
+    {
+        var rules = Settings.HiddenIcons?.Content;
+        var signature = 17;
+        if (rules != null)
+        {
+            foreach (var rule in rules)
+            {
+                if (rule == null) continue;
+                signature = signature * 31 + (rule.Hide.Value ? 1 : 0);
+                signature = signature * 31 + (rule.MetadataRegex?.Value?.GetHashCode() ?? 0);
+            }
+        }
+
+        if (signature == _hiddenIconSignature) return;
+        _hiddenIconSignature = signature;
+        _hiddenIconCache.Clear();
+    }
+
+    private bool IsHiddenByRule(string path)
+    {
+        if (string.IsNullOrEmpty(path)) return false;
+        var rules = Settings.HiddenIcons?.Content;
+        if (rules == null || rules.Count == 0) return false;
+        if (_hiddenIconCache.TryGetValue(path, out var cached)) return cached;
+
+        var hidden = false;
+        foreach (var rule in rules)
+        {
+            if (rule == null || !rule.Hide.Value) continue;
+            var pattern = rule.MetadataRegex?.Value;
+            if (string.IsNullOrWhiteSpace(pattern)) continue;
+
+            var regex = GetHiddenIconRegex(pattern);
+            if (regex != null && regex.IsMatch(path))
+            {
+                hidden = true;
+                break;
+            }
+        }
+
+        _hiddenIconCache[path] = hidden;
+        return hidden;
+    }
+
+    private Regex GetHiddenIconRegex(string pattern)
+    {
+        if (_hiddenIconRegexes.TryGetValue(pattern, out var cached)) return cached;
+        // A half-typed pattern is a normal state while editing the field, so a pattern that fails
+        // to compile is reported once and then skipped rather than logged every frame.
+        if (_badHiddenIconPatterns.Contains(pattern)) return null;
+
+        try
+        {
+            var regex = new Regex(pattern, RegexOptions.Compiled);
+            _hiddenIconRegexes[pattern] = regex;
+            return regex;
+        }
+        catch (ArgumentException ex)
+        {
+            _badHiddenIconPatterns.Add(pattern);
+            LogError($"MinimapIcons: invalid hidden icon regex '{pattern}' -- rule skipped. {ex.Message}");
+            return null;
         }
     }
 


### PR DESCRIPTION
### Problem

Both existing ways to suppress an icon run at icon *creation*. An entry in `ignored_entities.txt`, or in the hardcoded `MinimapIcons.Ignored` list, makes `IconsBuilder.SkipIcon` return before an icon object exists:

```csharp
if (IgnoredEntities.Any(x => entity.Path?.Contains(x) == true)) return true;
```

Two consequences:

- **An exclusion can't be undone without an area change.** `ReadIgnoreFile` only runs on `AreaChange`, and even after a reload the icon was never built, so there's nothing to draw.
- **`MinimapIcons.Ignored` can't be undone at all** without editing the plugin and rebuilding.

There's also no way to add an exclusion from the UI — you have to find the metadata path, locate the right file, and change zone.

What sent me looking: a Fortress map with ~30 `Metadata/Monsters/LeagueHeist/Robot/LightBot/MapLightBot` in it. They're hostile white monsters, so `MonsterIcon` gives them the same large red circle as a real pack, but they're ambient props you never fight — enough dots to make the map hard to read.

### Change

A `ContentNode<IconIgnoreRule>` in the settings menu. Each row is a label, an unanchored metadata regex, and its own `Hide` toggle. Matching runs in the draw loop, right after the existing `Ignored` check:

```csharp
if (IsHiddenByRule(icon.Entity.Path))
    continue;
```

Because it's applied at draw time rather than at creation, a toggle takes effect on the next frame **in both directions** — an unwanted icon can be silenced, and brought back, without a restart or a rebuild.

**The list ships empty, so behaviour is unchanged unless a rule is added.** The change is purely additive: 156 insertions, no deletions, nothing existing touched.

### Performance

`Render()` runs every frame, so the matching is kept cheap:

- Regexes compile once per pattern and are cached by pattern text.
- `path -> hide` answers are cached, so a breach with hundreds of entities behind a handful of distinct paths costs one dictionary hit per icon.
- The cache is invalidated by a per-frame **integer** hash of the rule set, not by building and comparing a string, so the per-frame path doesn't allocate.
- A pattern that fails to compile is logged once and then skipped — a half-typed regex is a normal state while editing the field, not something to log every frame or take the other rules down with.

### Notes

`IconIgnoreRule.ToString()` names the row in the settings UI, which otherwise falls back to `object.ToString()` and shows every row as `MinimapIcons.IconIgnoreRule`. It ends in `###` so the ImGui id stays stable while the visible label changes, otherwise the row collapses itself as you type — same idiom used for `ContentNode` rows elsewhere in the ecosystem.

### Testing

Built against ExileCore on `net10.0-windows`, 0 warnings, 0 errors, and run in-game. Verified with a temporary per-frame dump of every icon that survives the filter chain:

- Rule on, pattern `Metadata/Monsters/RockGolem/` → 91 icons drawn, **no `RockGolemSummoned`**, while `ChaosElementalSummoned`, `LightningGolemSummoned` and `FireElementalSummoned` all still drew. Sibling paths unaffected.
- Same rule toggled off → `RockGolemSummoned` back.
- With the light bots rule on, the five red dots on the large map disappeared; their five drawn-icon entries matched the dots' screen positions one-to-one beforehand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
